### PR TITLE
Fix validation after pasting number

### DIFF
--- a/app/src/main/java/io/github/subhamtyagi/openinwhatsapp/fragment/BaseFragment.java
+++ b/app/src/main/java/io/github/subhamtyagi/openinwhatsapp/fragment/BaseFragment.java
@@ -598,6 +598,7 @@ public abstract class BaseFragment extends Fragment {
     protected String validate() {
         String region = null;
         String phone = null;
+        mLastEnteredPhone = mPhoneEdit.getText().toString();
         if (mLastEnteredPhone != null) {
             try {
                 Phonenumber.PhoneNumber p = mPhoneNumberUtil.parse(mLastEnteredPhone, null);


### PR DESCRIPTION
For some strange reason, a phone number is currently not recognized as valid when it was not typed manually. This workaround fixes this issue.

Also related to #2, as this PR eliminates the same weird behavior which existed after pasting.