### PR TITLE
Add OpenInWhatsapp to contact share dialog

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,12 @@
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
-
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/x-vcard" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/io/github/subhamtyagi/openinwhatsapp/fragment/BaseFragment.java
+++ b/app/src/main/java/io/github/subhamtyagi/openinwhatsapp/fragment/BaseFragment.java
@@ -371,6 +371,8 @@ public abstract class BaseFragment extends Fragment {
 
     protected SparseArray<ArrayList<Country>> mCountriesMap = new SparseArray<ArrayList<Country>>();
 
+    protected boolean isShare = false;
+
     protected PhoneNumberUtil mPhoneNumberUtil = PhoneNumberUtil.getInstance();
     protected Spinner mSpinner;
 
@@ -390,8 +392,12 @@ public abstract class BaseFragment extends Fragment {
             if (mLastEnteredPhone != null && mLastEnteredPhone.startsWith(c.getCountryCodeStr())) {
                 return;
             }
-            mPhoneEdit.getText().clear();
-            mPhoneEdit.getText().insert(mPhoneEdit.getText().length() > 0 ? 1 : 0, String.valueOf(c.getCountryCode()));
+            if (!isShare) {
+                mPhoneEdit.getText().clear();
+                mPhoneEdit.getText().insert(mPhoneEdit.getText().length() > 0 ? 1 : 0, String.valueOf(c.getCountryCode()));
+            } else {
+                isShare = false;
+            }
             mPhoneEdit.setSelection(mPhoneEdit.length());
             mLastEnteredPhone = null;
         }

--- a/app/src/main/java/io/github/subhamtyagi/openinwhatsapp/fragment/MainFragment.java
+++ b/app/src/main/java/io/github/subhamtyagi/openinwhatsapp/fragment/MainFragment.java
@@ -3,12 +3,15 @@
 package io.github.subhamtyagi.openinwhatsapp.fragment;
 
 import android.content.ComponentName;
+import android.content.ContentResolver;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.io.InputStream;
 import java.net.URISyntaxException;
 
 import io.github.subhamtyagi.openinwhatsapp.R;
@@ -18,6 +21,51 @@ public class MainFragment extends BaseFragment {
     private String number;
 
     public MainFragment() {
+    }
+
+    @Override
+    public void onStart() {
+        Intent intent = getActivity().getIntent();
+        String action = intent.getAction();
+
+        if (Intent.ACTION_SEND.equals(action)) {
+            String type = intent.getType();
+            if ("text/x-vcard".equals(type)) {
+                isShare = true;
+
+                Uri contactUri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+
+                ContentResolver cr = getContext().getContentResolver();
+                String data = "";
+                try {
+                    InputStream stream = cr.openInputStream(contactUri);
+
+                    StringBuffer fileContent = new StringBuffer("");
+                    int ch;
+                    while( (ch = stream.read()) != -1)
+                        fileContent.append((char)ch);
+                    stream.close();
+
+                    data = new String(fileContent);
+
+                } catch (Exception e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+
+                for (String line : data.split("\n")) {
+                    line = line.trim();
+                    //todo: support other phone numbers from vcard
+                    if (line.startsWith("TEL;CELL:")) {
+                        number = line.substring(9);
+                        mPhoneEdit.setText(number);
+                        mOnPhoneChangedListener.onPhoneChanged(number);
+                    }
+                }
+            }
+        }
+
+        super.onStart();
     }
 
     @Override


### PR DESCRIPTION
With this PR, OpenInWhatsapp is able to get a phone number from a shared contact. The vcard parsing is done manually, but should work in most of the cases.

Please note that #5 is required for this feature to work properly.
